### PR TITLE
Pus 3122/fix inflight requests during shutdown

### DIFF
--- a/src/broen.app.src
+++ b/src/broen.app.src
@@ -1,7 +1,7 @@
 {application, broen,
   [
     {description, "broen provides a bridge between HTTP and AMQP"},
-    {vsn, "3.0.2"},
+    {vsn, "3.0.3"},
     {registered, []},
     {applications, [
       kernel,
@@ -10,9 +10,9 @@
       iso8601,
       inets,
       mnesia,
-      cowboy,
       folsom,
       amqp_director,
+      cowboy,
       jsx
     ]},
     {mod, {broen_app, []}},


### PR DESCRIPTION
Shutting down the `http` server (`cowboy`) before `amqp_director` should ensure we stop receiving requests.
It is still possible though that some request will be lost in the process, as I couldn't find a way to ensure that requests that are being processed (ie. we are awaiting a response from `amqp`) are handled before closing the system.